### PR TITLE
removing array_merge_recursive

### DIFF
--- a/src/SimpleCacheTranslator.php
+++ b/src/SimpleCacheTranslator.php
@@ -450,7 +450,7 @@ class SimpleCacheTranslator implements TranslatorInterface
             if (!$this->translations) {
                 $this->translations = $a;
             } else {
-                $this->translations = array_merge_recursive($this->translations, $a);
+                $this->translations = array_merge($this->translations, $a);
             }
         }
     }


### PR DESCRIPTION
I don't understand why we would be using array_merge_recursive. This has an unexpected side effect. 
The contents of $this->translations is normally an array of strings.
But now sometimes it can be an array of an array.. which is not what the translator services expect.

I do like @spekary  to check this out before merging though, because I'm unsure of the reasoning behind this.