### PR TITLE
assert and skip writing cache

### DIFF
--- a/src/SimpleCacheTranslator.php
+++ b/src/SimpleCacheTranslator.php
@@ -625,7 +625,11 @@ class SimpleCacheTranslator implements TranslatorInterface
         // Stackexhchange lore suggests that json encode is the fastest way to do this using standard PHP calls,
         // though igbinary may be even faster, but we don't want to make that a dependency at this point.
         $strEncodedData = json_encode($data);
-        file_put_contents($this->getTempFileName($strDomain), $strEncodedData, LOCK_EX);
+        if($strEncodedData) {
+			file_put_contents($this->getTempFileName($strDomain), $strEncodedData, LOCK_EX);
+		} else {
+			assert(false, 'Translation cannot be json_encoded, check the source file for domain ' . $strDomain . '. Original json error: ' . json_last_error_msg());
+		}
     }
 
     /**


### PR DESCRIPTION
When we json_encode to send to the cache, it might fail. Usually happens when there is a faulty UTF-8 conversion.
We can catch this by looking at the result of json_encode. We can keep the application working, by just skipping caching write. And we notify the developer by asserting.